### PR TITLE
 feat: implement blog likes/upvotes

### DIFF
--- a/src/controllers/like.controller.ts
+++ b/src/controllers/like.controller.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import { LikeService } from "../services/like.service";
+
+export const toggleLike = async (req: Request, res: Response) => {
+  const { blogId } = req.params;
+  const userID = (req as any).userId;
+  try {
+    const { likes, hasLiked } = await LikeService.toggleLike(userID, blogId);
+    return res
+      .status(200)
+      .json({ message: hasLiked ? "Unliked" : "Liked", likes });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to Like blog",
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+};

--- a/src/models/blog.model.ts
+++ b/src/models/blog.model.ts
@@ -1,4 +1,4 @@
-import mongoose, { mongo } from "mongoose";
+import mongoose, { mongo, Schema } from "mongoose";
 import { IBlog } from "../types/types";
 
 const blogSchema = new mongoose.Schema<IBlog>(
@@ -31,10 +31,15 @@ const blogSchema = new mongoose.Schema<IBlog>(
       required: true,
     },
     author: {
-      type: mongoose.Schema.Types.ObjectId,
+      type: mongoose.Types.ObjectId,
       ref: "User",
       required: true,
     },
+    likes: {
+      type: Number,
+      default: 0,
+    },
+    likedBy: [{ type: mongoose.Types.ObjectId, ref: "User" }],
   },
   { timestamps: true }
 );

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import authRouter from "./auth.routes";
 import blogRouter from "./blog.routes";
 import UserRouter from "./user.routes";
 import commentRouter from "./comment.routes";
+import likeRouter from "./like.routes";
 import { Router } from "express";
 
 const router = Router();
@@ -10,5 +11,6 @@ router.use("/auth", authRouter);
 router.use("/blog", blogRouter);
 router.use("/user", UserRouter);
 router.use("/comment", commentRouter);
+router.use("/like", likeRouter);
 
 export default router;

--- a/src/routes/like.routes.ts
+++ b/src/routes/like.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { isAutenticated } from "../middlewares/auth.middleware";
+import { toggleLike } from "../controllers/like.controller";
+
+const router = Router();
+
+router.post("/:blogId/toggle", isAutenticated, toggleLike);
+
+export default router;

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -1,0 +1,23 @@
+import mongoose from "mongoose";
+import Blog from "../models/blog.model";
+
+export class LikeService {
+  static async toggleLike(userId: string, blogId: string) {
+    const blog = await Blog.findById(blogId);
+    if (!blog) throw new Error("Blog not found");
+
+    const Uid = new mongoose.Types.ObjectId(userId);
+
+    const hasLiked = blog.likedBy.some((id) => id.toString() === userId);
+
+    if (hasLiked) {
+      blog.likedBy = blog.likedBy.filter((id) => id.toString() !== userId);
+      blog.likes -= 1;
+    } else {
+      blog.likedBy.push(Uid);
+      blog.likes += 1;
+    }
+    await blog.save();
+    return { likes: blog.likes, hasLiked };
+  }
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import { Document, ObjectId } from "mongoose";
+import mongoose, { Document, ObjectId } from "mongoose";
 export interface Iuser extends Document {
   _id: ObjectId;
   first_name: string;
@@ -19,6 +19,8 @@ export interface IBlog extends Document {
   state: "draft" | "published";
   read_count: number;
   reading_time: number;
+  likes: number;
+  likedBy: mongoose.Types.ObjectId[];
   timestamp: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Description
This PR adds a **like/upvote system** for blogs. Authenticated users can now like or unlike blogs. Each blog tracks the total number of likes and prevents duplicate likes by the same user.

## Key Changes
- Updated `Blog` model:
  - Added `likes` (Number, default 0)
  - Added `likedBy` (array of user IDs)
- Created `like.controller.ts`:
  - `toggleLike` → handles both liking and unliking
- Added `like.routes.ts` with:
  - `POST /like/:blogId/toggle` → toggle like/unlike (auth required)
- Integrated like routes into the main router
- Secured with `authMiddleware` (only logged-in users can like/unlike)